### PR TITLE
npx sanity in build:sanity

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -6,7 +6,7 @@
 		"build": "npm run build:sanity && pwd && npm run build:web",
 		"build:web": "svelte-kit build",
 		"preview:web": "svelte-kit preview",
-		"build:sanity": "cd studio && yarn && sanity build ../static/studio -y && cd ..",
+		"build:sanity": "cd studio && yarn && npx sanity build ../static/studio -y && cd ..",
 		"start:sanity": "cd studio && sanity start",
 		"lint": "prettier --ignore-path .gitignore --check --plugin-search-dir=. . && eslint --ignore-path .gitignore .",
 		"format": "prettier --ignore-path .gitignore --write --plugin-search-dir=. ."


### PR DESCRIPTION
very excited to see this repo, thanks @hdoro @stordahl for your work on this so far

obviously it's still a [work in progress](https://github.com/sanity-io/sanity-template-svelte-kit-blog), but I did manage to finally get the svelte kit part deployed to vercel by adding `npx` to the `build:sanity` [script](https://github.com/sanity-io/sanity-template-svelte-kit-blog/blob/a99ae61dc0e4d1d2b6ea95050e5e36c703002257/template/package.json#L9):

```diff
- "build:sanity": "cd studio && yarn && sanity build ../static/studio -y && cd ..",
+ "build:sanity": "cd studio && yarn && npx sanity build ../static/studio -y && cd ..",
```

is this something that would be useful to merge?

side note, I still haven't been able to get the studio connected to sanity after using [this link](https://www.sanity.io/create?template=sanity-io%2Fsanity-template-svelte-kit-blog) to set things up though

stuck "Connecting to Sanity.io" when I visit /studio (which could possibly relate to the initial post-create deployments failing with `sh: sanity: command not found`)