### PR TITLE
Updated 'svelte' to 'sveltekit' in app template

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -2,12 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%svelte.assets%/favicon.png" />
+    <link rel="icon" href="%sveltekit.assets%/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    %svelte.head%
+    %sveltekit.head%
     <link rel="stylesheet" href="https://vanillacss.com/vanilla.css" />
   </head>
   <body>
-    <div>%svelte.body%</div>
+    <div>%sveltekit.body%</div>
   </body>
 </html>


### PR DESCRIPTION
Running dev presented an issue about the template naming convention, using `sveltekit` instead of `svelte`.